### PR TITLE
Fix compilation in debian buster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 setup_env:
 ifeq (,$(wildcard ${ROOT_DIR}/.venv/bin/python))
 	$(eval $(call vars,$@))
-	rm -rf ${ROOT_DIR}/.venv
-	python -m venv ${ROOT_DIR}/.venv
-	pip install build
-	${ROOT_DIR}/.venv/bin/pip install -e .[dev]
+	${ROOT_DIR}/buildscripts/make_venv.sh "${ROOT_DIR}"
 endif
 
 .PHONY: clean

--- a/buildscripts/make_venv.sh
+++ b/buildscripts/make_venv.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+ROOT_DIR="$1"
+
+if [ -z "$ROOT_DIR" ]  ; then
+    echo "ERROR: ROOT_DIR as argument required, but not received" >&2
+    exit 1
+fi
+
+if [ ! -d "${ROOT_DIR}" ]; then
+    echo "ERROR: $ROOT_DIR not found" >&2
+    exit 1
+fi
+
+rm -rf "${ROOT_DIR}/.venv"
+python3 -m venv "${ROOT_DIR}/.venv"
+. "${ROOT_DIR}/.venv/bin/activate"
+pip3 install build
+"${ROOT_DIR}/.venv/bin/pip3" install -e .[dev]


### PR DESCRIPTION
Debian buster deprecated support for python and only supports python3 

Debian buster deprecated pip install and only supports pip install inside venvs.

Loading the venv in the Makefile can be achieved if the build commands are run in a dedicated script.

This modification avoids the following error:

```
pip install build
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
make: *** [Makefile:11: setup_env] Error 1
```