### PR TITLE
Fix altium parser exits on unicode error with valid files

### DIFF
--- a/edaparts/utils/models_parser.py
+++ b/edaparts/utils/models_parser.py
@@ -115,7 +115,13 @@ def _parse_kicad_lib(path: pathlib.Path) -> dict[str, FootprintModel | SymbolMod
 
 
 def _parse_key_value_string(s):
-    properties = s.decode("utf-8").strip("|").split("|")
+    try:
+        properties = s.decode("utf-8").strip("|").split("|")
+    except UnicodeDecodeError as e:
+        __logger.warning("Error decoding: %s", e)
+        # Replace the invalid characters with a replacement character or empty string
+        properties = s.decode("utf-8", errors="replace").strip("|").split("|")
+
     result = {}
     for prop in properties:
         x = prop.split("=")


### PR DESCRIPTION
Some multi-component library files that seem to work correctly on Altium 25 casue the following error:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xae in position 143: invalid start byte
```

This commit works around that error and seems to get everything working.